### PR TITLE
Include templates in sdist (source distribution)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include flask_core/templates *


### PR DESCRIPTION
See discussion at https://github.com/pypa/sampleproject/issues/30#issuecomment-143947944

(Otherwise, `python3 setup.py install` will install a bdist which includes templates, yet `pip3 install flask-core/` will install an sdist which doesn't include templates)